### PR TITLE
13 stdlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,13 @@
 
 I had a bit of fun reading [TCL the Misunderstood](http://antirez.com/articoli/tclmisunderstood.html), and hacked up a simple TCL-like evaluator.
 
+The process was described a little in my blog here:
 
-## Building/Using
+* [Writing a simple TCL interpreter in golang](https://blog.steve.fi/writing_a_simple_tcl_interpreter_in_golang.html)
+
+
+
+## Building & Usage
 
 Build in the usual way, for example:
 
@@ -26,6 +31,15 @@ Execute with the name of a TCL-file to execute:
     ..
 ```
 
+The interpreter contains an embedded "standard-library", which you can view at [stdlib/stdlib.tcl](stdlib/stdlib.tcl), which is loaded along with any file that you specify.
+
+To disable the use of the standard library run:
+
+```sh
+   $ ./critical -no-stdlib path/to/file.tcl
+```
+
+
 
 ## Examples
 
@@ -37,7 +51,7 @@ The following is a simple example program which shows what the code here looks l
 // Fibonacci sequence, written in the naive/recursive fashion.
 //
 proc fib {x} {
-    if { expr $x <= 1 } {
+    if { <= $x 1 } {
         return 1
     } else {
         return [expr [fib [expr $x - 1]] + [fib [expr $x - 2]]]
@@ -51,7 +65,7 @@ proc fib {x} {
 set i 0
 set max 20
 
-while { expr $i <= $max } {
+while {<= $i $max } {
    puts "Fib $i is [fib $i]"
    incr i
 }
@@ -62,25 +76,22 @@ Another example is the test-code which @antirez posted with his [picol writeup](
 
 ```tcl
 proc square {x} {
-    expr $x * $x
+    * $x $x
 }
 
 set a 1
-while {expr $a <= 10} {
-    if {expr $a == 5} {
-        puts "\tMissing five!"
-        incr a
+while {<= $a 10} {
+    if {== $a 5} {
+        puts {Missing five!}
+        set a [+ $a 1]
         continue
-        puts "After continue this won't be executed"
     }
     puts "I can compute that $a*$a = [square $a]"
-    set a [expr $a + 1]
+    set a [+ $a 1]
 }
-
-puts "I'm alive; after the 'while' loop."
 ```
 
-This example is saved as [picol.tcl](picol.tcl) so you can run it from the repository:
+This example is contained within this repository as [picol.tcl](picol.tcl), so you can run it directly:
 
 ```sh
 go build . && ./critical ./picol.tcl
@@ -133,9 +144,6 @@ $ go test ./...
 
 In addition to the standard/static testing there are fuzz-based testers for the lexer and parser.  To run these run one of the following two sets of commands:
 
-* **NOTE**: The fuzz-tester requires the use of golang version 1.18 or higher.
-
-
 ```sh
 cd parser
 go test -fuzztime=300s -parallel=1 -fuzz=FuzzParser -v
@@ -146,6 +154,8 @@ cd lexer
 go test -fuzztime=300s -parallel=1 -fuzz=FuzzLexer -v
 
 ```
+
+
 ## Bugs?
 
 Yeah I'm not surprised.  Please feel free to open a new issue **with your example** included so I can see how to fix it.

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -63,6 +63,7 @@ func (e *Environment) Set(name string, value string) {
 
 		if ok {
 			e.parent.Set(name, value)
+			return
 		}
 	}
 

--- a/interpreter/arity_test.go
+++ b/interpreter/arity_test.go
@@ -8,9 +8,6 @@ func TestArity(t *testing.T) {
 	tests := []string{
 		`break "one"`,
 
-		`// "one"`,
-		`// "one" "two"`,
-
 		`continue "one" "two"`,
 
 		`decr`,

--- a/interpreter/builtin_comment.go
+++ b/interpreter/builtin_comment.go
@@ -1,13 +1,7 @@
 package interpreter
 
-import "fmt"
-
 // comment is a function which ignores comments "// xx" or "# xxxx".
 func comment(i *Interpreter, args []string) (string, error) {
-
-	if len(args) != 0 {
-		return "", fmt.Errorf("comment takes zero arguments")
-	}
 
 	return "", nil
 }

--- a/main.go
+++ b/main.go
@@ -1,30 +1,44 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
 
 	"github.com/skx/critical/interpreter"
+	"github.com/skx/critical/stdlib"
 )
 
 func main() {
 
+	noStdlib := flag.Bool("no-stdlib", false, "Disable the (embedded) standard library")
+	flag.Parse()
+
 	// Ensure we have a file to execute.
-	if len(os.Args) < 2 {
+	if len(flag.Args()) < 1 {
 		fmt.Printf("Usage: critical file.tcl\n")
 		return
 	}
 
-	// Read the file
-	data, err := ioutil.ReadFile(os.Args[1])
+	// Read our standard library
+	stdlib := stdlib.StdlibContents()
+
+	// Read the file the user wanted
+	data, err := ioutil.ReadFile(flag.Args()[0])
 	if err != nil {
 		fmt.Printf("error reading file %s:%s\n", os.Args[0], err)
 		return
 	}
 
+	// Join the two inputs, unless we shouldn't.
+	input := string(data)
+	if !*noStdlib {
+		input = string(stdlib) + "\n" + input
+	}
+
 	// Create the interpreter
-	interpreter := interpreter.New(string(data))
+	interpreter := interpreter.New(input)
 
 	// Evaluate the input
 	out, err := interpreter.Evaluate()

--- a/picol.tcl
+++ b/picol.tcl
@@ -1,17 +1,18 @@
+// Procedure (i.e. function) which squares the given number.
 proc square {x} {
     expr $x * $x
 }
 
 set a 1
-while {expr $a <= 10} {
-    if {expr $a == 5} {
+while {<= $a 10} {
+    if {== $a 5} {
         puts "\tMissing five!"
-        incr a
+        set a [+ $a 1]
         continue
         puts "After continue this won't be executed"
     }
     puts "I can compute that $a*$a = [square $a]"
-    set a [expr $a + 1]
+    set a [+ $a 1]
 }
 
 puts "I'm alive; after the 'while' loop."

--- a/stdlib/stdlib.go
+++ b/stdlib/stdlib.go
@@ -1,0 +1,16 @@
+// Package stdlib contains a simple/small standard-library, which
+// is written in TCL itself.
+//
+package stdlib
+
+import (
+	_ "embed" // embedded-resource magic
+)
+
+//go:embed stdlib.tcl
+var message string
+
+// StdlibContents returns the embedded TCL code.
+func StdlibContents() []byte {
+	return []byte(message)
+}

--- a/stdlib/stdlib.tcl
+++ b/stdlib/stdlib.tcl
@@ -1,0 +1,82 @@
+//
+// This is the "standard library".
+//
+// We define some functions here which are available to all users
+// of our application/scripting language.
+//
+
+
+//
+// Maths functions should be easier to use.
+//
+// So we can write:
+//
+//    while { <= $a 5 } { .. }
+//
+// instead of
+//
+//    while { expr $a <= 5 } { ... }
+//
+
+proc + {a b} {
+    expr $a + $b
+}
+proc - {a b} {
+    expr $a - $b
+}
+proc / {a b} {
+    expr $a / $b
+}
+proc * {a b} {
+    expr $a * $b
+}
+
+//
+// Comparison functions
+//
+proc < {a b} {
+    expr $a < $b
+}
+proc <= {a b} {
+    expr $a <= $b
+}
+proc > {a b} {
+    expr $a > $b
+}
+proc >= {a b} {
+    expr $a >= $b
+}
+
+//
+// Equality
+//
+proc == {a b} {
+    expr $a == $b
+}
+
+//
+// Utility functions
+//
+proc repeat {n body} {
+    set res ""
+    while {> $n 0} {
+        decr n
+        set res [$body]
+    }
+    $res
+}
+
+
+//
+// Now that we have a "repeat" function defined we could use it like so:
+//
+//   repeat 5 {
+//        puts "Hello I'm alive";
+//   }
+//
+// This would also work:
+//
+//   set foo 12
+//   repeat 5 { incr foo }
+//   => foo is now 17 (i.e. 12 + 5)
+//


### PR DESCRIPTION
Add a simple standard-library, and use it.
    
Updated the examples to use `{<= $a 10}` rather than the other form (`{expr $a <= 10}`) which works now we've added corresponding helper methods as part of a "standard library".
    
The library is added/loaded by the driver rather than the core interpreter in case users don't need/want it, but this is a reasonably easy thing to change in the future.
    
The only things added right now are the maths/comparision functions and a single proc named `repeat`.
    
This closes #13.
