### PR TITLE
Floating point support

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,16 +127,15 @@ The complete list of standard [TCL commands](https://www.tcl.tk/man/tcl/TclCmd/c
 
 Read the file [input.tcl](input.tcl) to get a feel for the language, but in-brief you've got the following facilities available:
 
-* Mathematical operations for `expr`
-  * `+` `-` `/` `*` `<` `>` `<=` `>=`
-  * Integer support only.  Sigh.
+* Floating-point mathematical operations for `expr`
+  * `+` `-` `/` `*` `%`.
+* Comparison operations for `expr`
+  * `<` `>` `<=` `>=`, `==`, `!=`, `eq`, `ne`
 * Output to STDOUT via `puts`.
-* Inline command expansion.
-  * Including inside strings.
-* Inline variable expansion.
-  * Including inside strings.
+* Inline command expansion, for example `puts [* 3 4]`
+* Inline variable expansion, for example `puts "$$name is $name"`.
 * The ability to define procedures, via `proc`.
-
+  * See the later examples, or examine code such as [examples/prime.tcl](examples/prime.tcl).
 
 
 ## Missing Features

--- a/input.tcl
+++ b/input.tcl
@@ -1,6 +1,6 @@
-// variable
-set a [ expr 2 + 2 ]
-puts "A is set to: $a"
+// Set a variable
+set a 43.1
+puts "Variable a, ($$a), is set to: $a"
 
 // variable expansion comes before execution.
 set a pu
@@ -8,10 +8,12 @@ set b ts
 $a$b "Hello World"
 
 // expansion, once again.
+// replacing things between the brackets with the output from executing them
 puts [set a 4]
 puts [set a]
 
-set name "Steve"
+// Variables can be longer.
+set name "Steve Kemp"
 puts "Hello World my name is $name"
 
 // We have a standard library, located in `stdlib/stdlib.tcl`
@@ -22,8 +24,9 @@ puts "Hello World my name is $name"
 // This will do "string" or "number" comparisons, and terminate
 // execution on failure.
 //
-assert_equal "$name" "Steve"
+assert_equal "$name" "Steve Kemp"
 assert_equal 9 [expr 3 * 3]
+assert_equal 7.4 [- [+ 7 1.4] 1]
 assert_equal 12 [+ 10 2]
 
 // conditional
@@ -38,8 +41,8 @@ if { "steve" } { puts "OK: steve was ok" } else { puts "steve was not ok" }
 //  "b" => "ts"
 //  "x" => UNDEFINED
 //
-if { $a } { puts "A is set" } else { puts "A is NOT set" }
-if { $x } { puts "X is set - This is a bug" } else { puts "X is NOT set" }
+if { $a } { puts "$$a is set" } else { puts "$$a is NOT set" }
+if { $x } { puts "$$x is set - This is a bug" } else { puts "$$x is NOT set" }
 
 //
 // Setup some variables for a loop.
@@ -57,6 +60,7 @@ while { expr $i <= $max } {
    incr i
 }
 
+// Show the sum
 puts "Sum of 1..10 (==(10x11)/2): $sum"
 
 
@@ -65,7 +69,7 @@ puts "Sum of 1..10 (==(10x11)/2): $sum"
 //
 // Our first user-defined function!
 //
-proc inc {x} { puts "X is $x"; expr $x + 1 }
+proc inc {x} { puts "$$x is $x"; expr $x + 1 }
 puts "3 inc is [inc 3]"
 
 //

--- a/interpreter/builtin_decr.go
+++ b/interpreter/builtin_decr.go
@@ -23,19 +23,25 @@ func decr(i *Interpreter, args []string) (string, error) {
 	}
 
 	// How much to decrease by?
-	decrease := 1
+	decrease := 1.0
 	if len(args) == 2 {
 		var err error
-		decrease, err = strconv.Atoi(args[1])
+		decrease, err = strconv.ParseFloat(args[1], 64)
 		if err != nil {
 			return "", err
 		}
 	}
 
-	orig, _ := strconv.Atoi(cur)
+	orig, _ := strconv.ParseFloat(cur, 64)
 	orig -= decrease
-	i.environment.Set(name, fmt.Sprintf("%d", orig))
 
-	return fmt.Sprintf("%d", orig), nil
+	// an integer, really?
+	if orig == float64(int(orig)) {
+		i.environment.Set(name, fmt.Sprintf("%d", int(orig)))
+		return fmt.Sprintf("%d", int(orig)), nil
+	}
+
+	i.environment.Set(name, fmt.Sprintf("%f", orig))
+	return fmt.Sprintf("%f", orig), nil
 
 }

--- a/interpreter/builtin_expr.go
+++ b/interpreter/builtin_expr.go
@@ -11,12 +11,12 @@ func expr(i *Interpreter, args []string) (string, error) {
 		return "", fmt.Errorf("expr requires three arguments, got %d", len(args))
 	}
 
-	aV, eA := strconv.Atoi(args[0])
+	aV, eA := strconv.ParseFloat(args[0], 64)
 	if eA != nil && (args[1] != "ne" && args[1] != "eq") {
 		return "", eA
 	}
 	op := args[1]
-	bV, eB := strconv.Atoi(args[2])
+	bV, eB := strconv.ParseFloat(args[2], 64)
 	if eB != nil && (args[1] != "ne" && args[1] != "eq") {
 		return "", eB
 	}
@@ -37,15 +37,41 @@ func expr(i *Interpreter, args []string) (string, error) {
 		return "0", nil
 
 	case "+":
-		return (fmt.Sprintf("%d", aV+bV)), nil
+		x := aV + bV
+
+		// an integer, really?
+		if x == float64(int(x)) {
+			return fmt.Sprintf("%d", int(x)), nil
+		}
+
+		return (fmt.Sprintf("%f", x)), nil
 	case "-":
-		return (fmt.Sprintf("%d", aV-bV)), nil
+		x := aV - bV
+		// an integer, really?
+		if x == float64(int(x)) {
+			return fmt.Sprintf("%d", int(x)), nil
+		}
+
+		return (fmt.Sprintf("%f", x)), nil
 	case "*":
-		return (fmt.Sprintf("%d", aV*bV)), nil
+		x := aV * bV
+		// an integer, really?
+		if x == float64(int(x)) {
+			return fmt.Sprintf("%d", int(x)), nil
+		}
+
+		return (fmt.Sprintf("%f", x)), nil
+
 	case "/":
-		return (fmt.Sprintf("%d", aV/bV)), nil
+		x := aV / bV
+		// an integer, really?
+		if x == float64(int(x)) {
+			return fmt.Sprintf("%d", int(x)), nil
+		}
+
+		return (fmt.Sprintf("%f", x)), nil
 	case "%":
-		return (fmt.Sprintf("%d", aV%bV)), nil
+		return (fmt.Sprintf("%d", int(aV)%int(bV))), nil
 	case "<":
 		if aV < bV {
 			return "1", nil

--- a/interpreter/builtin_incr.go
+++ b/interpreter/builtin_incr.go
@@ -23,18 +23,25 @@ func incr(i *Interpreter, args []string) (string, error) {
 	}
 
 	// How much to increase by?
-	increase := 1
+	increase := 1.0
 	if len(args) == 2 {
 		var err error
-		increase, err = strconv.Atoi(args[1])
+		increase, err = strconv.ParseFloat(args[1], 64)
 		if err != nil {
 			return "", err
 		}
 	}
 
-	orig, _ := strconv.Atoi(cur)
+	orig, _ := strconv.ParseFloat(cur, 64)
 	orig += increase
-	i.environment.Set(name, fmt.Sprintf("%d", orig))
 
-	return fmt.Sprintf("%d", orig), nil
+	// an integer, really?
+	if orig == float64(int(orig)) {
+		i.environment.Set(name, fmt.Sprintf("%d", int(orig)))
+		return fmt.Sprintf("%d", int(orig)), nil
+	}
+
+	// A floating-point number
+	i.environment.Set(name, fmt.Sprintf("%f", orig))
+	return fmt.Sprintf("%f", orig), nil
 }

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -154,21 +154,9 @@ func TestParseNumber(t *testing.T) {
 	lex = New("10-10")
 	tok = lex.NextToken()
 	if tok.Type != token.ILLEGAL {
-		t.Fatalf("parsed number as wrong type")
+		t.Fatalf("parsed number as wrong type: %v", tok)
 	}
 	if !strings.Contains(tok.Literal, "'-' may only occur at the start of the number") {
-		t.Fatalf("got error, but wrong one: %s", tok.Literal)
-	}
-
-	// Now a number that's out of range.
-	lex = New("18446744073709551620")
-
-	tok = lex.NextToken()
-
-	if tok.Type != token.ILLEGAL {
-		t.Fatalf("parsed number as wrong type")
-	}
-	if !strings.Contains(tok.Literal, "out of range") {
 		t.Fatalf("got error, but wrong one: %s", tok.Literal)
 	}
 
@@ -234,10 +222,9 @@ func TestInteger(t *testing.T) {
 	tests := []TestCase{
 		{input: "3", output: "3"},
 		{input: "-3", output: "-3"},
-		{input: "-0", output: "0"},
+		{input: "-0", output: "-0"},
 		{input: "-10", output: "-10"},
-		{input: "0xff", output: "255"},
-		{input: "0b11111111", output: "255"},
+		{input: "0xff", output: "0xff"},
 	}
 
 	for _, tst := range tests {


### PR DESCRIPTION
This pull-request adds floating-point support to `expr`, and to the lexer.

The end result is that `puts [/ 3 4]` behaves in the way you'd expect.

