### PR TITLE
22 testing

### DIFF
--- a/interpreter/builtin_decr_test.go
+++ b/interpreter/builtin_decr_test.go
@@ -59,4 +59,22 @@ func TestDecr(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error decreasing")
 	}
+
+	// floating-point decrement
+	out, err = set(e, []string{"steve", "3.1"})
+	if out != "3.1" {
+		t.Fatalf("set had the wrong result %s != 3.1", out)
+	}
+	if err != nil {
+		t.Fatalf("unexpected error")
+	}
+
+	// Now decrease it by one.
+	out, err = decr(e, []string{"steve"})
+	if out != "2.100000" {
+		t.Fatalf("decr had the wrong result: %s", out)
+	}
+	if err != nil {
+		t.Fatalf("unexpected error")
+	}
 }

--- a/interpreter/builtin_exit.go
+++ b/interpreter/builtin_exit.go
@@ -1,9 +1,14 @@
 package interpreter
 
 import (
+	"errors"
 	"fmt"
-	"os"
-	"strconv"
+)
+
+var (
+	// ErrExit is the "error" code a script will terminate with if
+	// it finishes execution with an `exit` statement.
+	ErrExit = errors.New("EXIT")
 )
 
 // exitFn is the golang implementation of the TCL `exit` function.
@@ -14,18 +19,5 @@ func exitFn(i *Interpreter, args []string) (string, error) {
 		return "", fmt.Errorf("exit only accepts one argument, got %d", len(args))
 	}
 
-	// Convert to an integer
-	var num int
-	var err error
-
-	num, err = strconv.Atoi(args[0])
-	if err != nil {
-
-		// error?
-		num = 1
-	}
-
-	os.Exit(num)
-
-	return "unreached", nil
+	return args[0], ErrExit
 }

--- a/interpreter/builtin_exit_test.go
+++ b/interpreter/builtin_exit_test.go
@@ -1,0 +1,77 @@
+package interpreter
+
+import (
+	"testing"
+)
+
+func TestExit(t *testing.T) {
+
+	// exit as a top-level
+	exit := `exit 32`
+
+	// exit within a loop
+	basic := `
+set sum 0
+set i 0
+
+while { expr $i < 10  } {
+   set sum [incr sum $i ]
+   exit 321
+   incr i
+}
+puts $sum
+`
+
+	// exit within a proc
+	proc := `
+proc foo {a} {
+   exit 43
+}
+foo 17
+`
+
+	// Run the exit-program
+	e := New(exit)
+	out, err := e.Evaluate()
+
+	// Is this error expected?
+	if err == nil {
+		t.Fatalf("expected error, but got none")
+	}
+	if err != ErrExit {
+		t.Fatalf("unexpected error running code:%s", err)
+	}
+	if out != "32" {
+		t.Fatalf("exit value didn't match - got '%s'", out)
+	}
+
+	// Run the loop-program
+	e = New(basic)
+	out, err = e.Evaluate()
+
+	// Is this error expected?
+	if err == nil {
+		t.Fatalf("expected error, but got none")
+	}
+	if err != ErrExit {
+		t.Fatalf("unexpected error running code:%s", err)
+	}
+	if out != "321" {
+		t.Fatalf("exit value didn't match - got '%s'", out)
+	}
+
+	// Run the proc-program
+	e = New(proc)
+	out, err = e.Evaluate()
+
+	// Is this error expected?
+	if err == nil {
+		t.Fatalf("expected error, but got none")
+	}
+	if err != ErrExit {
+		t.Fatalf("unexpected error running code:%s", err)
+	}
+	if out != "43" {
+		t.Fatalf("exit value didn't match - got '%s'", out)
+	}
+}

--- a/interpreter/builtin_expr_test.go
+++ b/interpreter/builtin_expr_test.go
@@ -16,21 +16,31 @@ func TestExpr(t *testing.T) {
 	tests := []TestCase{
 		// basic maths
 		{Input: []string{"3", "+", "3"}, Output: "6"},
+		{Input: []string{"3.1", "+", "3.3"}, Output: "6.400000"},
 		{Input: []string{"3", "*", "3"}, Output: "9"},
+		{Input: []string{"3.1", "*", "3"}, Output: "9.300000"},
 		{Input: []string{"3", "/", "3"}, Output: "1"},
+		{Input: []string{"3.1", "/", "3"}, Output: "1.033333"},
 		{Input: []string{"3", "-", "2"}, Output: "1"},
+		{Input: []string{"3.4", "-", "1.2"}, Output: "2.200000"},
 
 		// >
 		{Input: []string{"3", ">", "2"}, Output: "1"},
+		{Input: []string{"3.3", ">", "2"}, Output: "1"},
 		{Input: []string{"1", ">", "2"}, Output: "0"},
+		{Input: []string{"0.5", ">", "2"}, Output: "0"},
 
 		// >=
 		{Input: []string{"3", ">=", "3"}, Output: "1"},
+		{Input: []string{"3.1", ">=", "3"}, Output: "1"},
 		{Input: []string{"1", ">=", "2"}, Output: "0"},
+		{Input: []string{"0.74", ">=", "2"}, Output: "0"},
 
 		// <
 		{Input: []string{"3", "<", "3"}, Output: "0"},
+		{Input: []string{"3.0", "<", "3.0"}, Output: "0"},
 		{Input: []string{"1", "<", "2"}, Output: "1"},
+		{Input: []string{"1.4", "<", "2"}, Output: "1"},
 
 		// <=
 		{Input: []string{"3", "<=", "3"}, Output: "1"},
@@ -39,6 +49,10 @@ func TestExpr(t *testing.T) {
 		// ==
 		{Input: []string{"3", "==", "3"}, Output: "1"},
 		{Input: []string{"21", "==", "2"}, Output: "0"},
+
+		// !=
+		{Input: []string{"3", "!=", "3"}, Output: "0"},
+		{Input: []string{"21", "!=", "2"}, Output: "1"},
 
 		{Input: []string{"steve", "eq", "steve"}, Output: "1"},
 		{Input: []string{"steve", "eq", "Steve"}, Output: "0"},

--- a/interpreter/builtin_incr_test.go
+++ b/interpreter/builtin_incr_test.go
@@ -59,5 +59,25 @@ func TestIncr(t *testing.T) {
 	}
 	if err != nil {
 		t.Fatalf("unexpected error increasing")
+
 	}
+
+	// floating-point increment
+	out, err = set(e, []string{"steve", "3.1"})
+	if out != "3.1" {
+		t.Fatalf("set had the wrong result %s != 3.1", out)
+	}
+	if err != nil {
+		t.Fatalf("unexpected error setting steve->3")
+	}
+
+	// Now increase it by one.
+	out, err = incr(e, []string{"steve"})
+	if out != "4.100000" {
+		t.Fatalf("incr had the wrong result: %s", out)
+	}
+	if err != nil {
+		t.Fatalf("unexpected error")
+	}
+
 }

--- a/interpreter/builtin_while.go
+++ b/interpreter/builtin_while.go
@@ -39,8 +39,15 @@ func while(i *Interpreter, args []string) (string, error) {
 
 			// Nop
 
+		} else if err == ErrExit {
+
+			// Exit
+			return out, err
+
 		} else if err != nil {
-			return "", err
+
+			// Another, unexpected error
+			return out, err
 		}
 
 		// repeat the conditional-test ahead of repeating the body

--- a/lexer/fuzz_test.go
+++ b/lexer/fuzz_test.go
@@ -20,16 +20,15 @@ func FuzzLexer(f *testing.F) {
 
 	// Assignments
 	f.Add([]byte(`set a 3`))
+	f.Add([]byte(`set a 3.14`))
+	f.Add([]byte(`set a 0xff`))
+	f.Add([]byte(`set a 0b01010`))
 	f.Add([]byte(`set a`))
 	f.Add([]byte(`let b "Hello"`))
 
-	// Known errors are listed here.
-	//
-	// The purpose of fuzzing is to find panics, or unexpected errors.
-	//
-	// Some programs are obviously invalid though, so we don't want to
-	// report those known-bad things.
-	//	known := []string{}
+	// Errors
+	f.Add([]byte(`set a "steve`))
+	f.Add([]byte(`set a 10-21`))
 
 	f.Fuzz(func(t *testing.T, input []byte) {
 

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -159,7 +159,6 @@ func TestParseNumber(t *testing.T) {
 	if !strings.Contains(tok.Literal, "'-' may only occur at the start of the number") {
 		t.Fatalf("got error, but wrong one: %s", tok.Literal)
 	}
-
 }
 
 // TestIllegal looks for some illegal inputs
@@ -225,6 +224,8 @@ func TestInteger(t *testing.T) {
 		{input: "-0", output: "-0"},
 		{input: "-10", output: "-10"},
 		{input: "0xff", output: "0xff"},
+		{input: "0b101", output: "0b101"},
+		{input: "3.14", output: "3.14"},
 	}
 
 	for _, tst := range tests {

--- a/parser/fuzz_test.go
+++ b/parser/fuzz_test.go
@@ -19,6 +19,8 @@ func FuzzParser(f *testing.F) {
 
 	// Assignments
 	f.Add([]byte(`set a 3`))
+	f.Add([]byte(`set a 3.32`))
+	f.Add([]byte(`set a 10-10`))
 	f.Add([]byte(`set a`))
 
 	// and with usage


### PR DESCRIPTION
This pull-request, once complete, will close #22 by giving us 100% test-coverage of all our internal packages.

* Add floating-point tests.
* Add coverage for the `exit` primitive
  * Which should return an `error` (as `break`, `continue`, and `return` do), rather than actually calling `os.Exit`.
* Add a method to register built-in functions, and use it.
  * This will help with #21.
