### PR TITLE
Added benchmark - and allow Evaluate to be called N times

### DIFF
--- a/interpreter/benchmark_test.go
+++ b/interpreter/benchmark_test.go
@@ -1,0 +1,63 @@
+package interpreter
+
+import (
+	"testing"
+)
+
+// Benchmark_simple_return - This benchmark shows the overhead of just
+// invoking a single `return` word.
+//
+func Benchmark_simple_return(b *testing.B) {
+
+	//
+	// Source code of the script we're going to run
+	//
+	src := `return 34`
+
+	//
+	// Create the interpreter
+	//
+	i, er := New(src)
+	if er != nil {
+		b.Fatalf("unexpected error creating interpreter")
+	}
+
+	//
+	// return values
+	//
+	var err error
+	var out string
+
+	//
+	// Now run the thing in a loop
+	//
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+
+		// execute
+		out, err = i.Evaluate()
+
+		// Ensure that the results are what we expect
+		//
+		// NOTE: This will kill the benchmark throughput a little.
+		//
+		if err != nil && err != ErrReturn {
+			b.Fatal(err)
+		}
+		if out != "34" {
+			b.Fail()
+		}
+
+	}
+	b.StopTimer()
+
+	//
+	// Final execution is tested again.
+	//
+	if err != nil && err != ErrReturn {
+		b.Fatal(err)
+	}
+	if out != "34" {
+		b.Fail()
+	}
+}


### PR DESCRIPTION
Previously we invoked our parser, to parse the input, in our
`Evaluate` call.  This meant that evaluating the same script
multiple times wasn't possible:

* First run:
  * Evaluate parses the program, executes each command.
* Second run
  * Evaluate has a parser which has already consumed the input.
  * There is nothing to parse.
  * So nothing is executed.

This pull-request moves the parser-consumption to the constructor,
which necessitated changing the constructor's signature, so that
the parser will always consume all input ahead of the call to
`Evaluate`.

The end result is you can run:

* New(..)
* Evalute
  * Runs the program.
* Evaluate
  * Runs the program, again.
* ..

This closes #25.