### PR TITLE
Correctly quote the return value from our proc

### DIFF
--- a/stdlib/stdlib.tcl
+++ b/stdlib/stdlib.tcl
@@ -122,7 +122,7 @@ proc repeat {n body} {
         decr n
         set res [$body]
     }
-    $res
+    "$res"
 }
 
 
@@ -169,5 +169,5 @@ proc loop {var min max bdy} {
     }
 
     // return the last result
-    $res
+    "$res"
 }


### PR DESCRIPTION
This stops them being interpreted as commands to execute in some
cases - which closes #29.