### PR TITLE
fix(words.go): FORTH -> TCL

### DIFF
--- a/embedded/words.go
+++ b/embedded/words.go
@@ -1,4 +1,4 @@
-// Implementation of words exported to FORTH.
+// Implementation of words exported to TCL.
 
 package main
 


### PR DESCRIPTION
This patch fixes a minor typo (perhaps occurring because you also wrote a FORTH interpreter).

(BTW, this repository is great, thank you!)